### PR TITLE
feat(minio): add podLabels support to bucket-init job

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/bucket-init-job.yaml
+++ b/charts/minio/templates/bucket-init-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "minio.fullname" . }}-post-job
+  name: {{ include "minio.fullname" . }}-bucket-init
   namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
@@ -20,8 +20,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "minio.selectorLabels" . | nindent 8 }}
+        {{- include "minio.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucket-init
+        {{- with .Values.bucketInitJob.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.bucketInitJob.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -30,6 +33,10 @@ spec:
 {{- with (include "minio.imagePullSecrets" .) }}
 {{ . | nindent 6 }}
 {{- end }}
+      serviceAccountName: {{ template "minio.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       restartPolicy: {{ .Values.bucketInitJob.restartPolicy }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       containers:

--- a/charts/minio/tests/bucket-init-job_test.yaml
+++ b/charts/minio/tests/bucket-init-job_test.yaml
@@ -1,0 +1,102 @@
+suite: test minio bucket-init-job
+templates:
+  - bucket-init-job.yaml
+  - bucket-init-configmap.yaml
+set:
+  image:
+    tag: RELEASE.2025-07-23T15-54-02Z@sha256:d249d1fb6966de4d8ad26c04754b545205ff15a62e4fd19ebd0f26fa5baacbc0
+  defaultBuckets: "test-bucket"
+tests:
+  - it: should render bucket-init job when defaultBuckets is set
+    template: bucket-init-job.yaml
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-minio-bucket-init
+
+  - it: should add podLabels to bucket-init job pods
+    template: bucket-init-job.yaml
+    set:
+      bucketInitJob:
+        podLabels:
+          sidecar.istio.io/inject: "false"
+          custom-label: "custom-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.template.metadata.labels["custom-label"]
+          value: "custom-value"
+
+  - it: should have selector labels and component label by default
+    template: bucket-init-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: minio
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: bucket-init
+
+  - it: should propagate commonLabels to pod template
+    template: bucket-init-job.yaml
+    set:
+      commonLabels:
+        environment: "production"
+        team: "platform"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: production
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+
+  - it: should add podAnnotations to bucket-init job pods
+    template: bucket-init-job.yaml
+    set:
+      bucketInitJob:
+        podAnnotations:
+          prometheus.io/scrape: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "false"
+
+  - it: should use default serviceAccountName
+    template: bucket-init-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-minio
+
+  - it: should use custom serviceAccountName
+    template: bucket-init-job.yaml
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa
+
+  - it: should set priorityClassName when specified
+    template: bucket-init-job.yaml
+    set:
+      priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: should not set priorityClassName when not specified
+    template: bucket-init-job.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -46,6 +46,9 @@
                 "podAnnotations": {
                     "type": "object"
                 },
+                "podLabels": {
+                    "type": "object"
+                },
                 "resources": {
                     "type": "object"
                 },
@@ -467,14 +470,6 @@
                 },
                 "fsGroupChangePolicy": {
                     "type": "string"
-                }
-            }
-        },
-        "postJob": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
                 }
             }
         },

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -81,12 +81,6 @@ config:
 ## e.g: "my-bucket, my-second-bucket:download, my-public-bucket:public"
 defaultBuckets: ""
 
-## @section postJob Configuration for the Job '{{ .Release.Name }}-post-job'
-postJob:
-  ## postJob.annotations Additional annotations for the Job
-  annotations:
-    helm.sh/hook: post-install,post-upgrade  # @schema hidden: true
-
 ## @section Bucket Initialization Job
 bucketInitJob:
   ## @param bucketInitJob.ttlSecondsAfterFinished Seconds after which the job is automatically deleted after completion (success or failure)
@@ -102,7 +96,13 @@ bucketInitJob:
   ## @param bucketInitJob.restartPolicy Restart policy for the job pods (OnFailure or Never)
   restartPolicy: OnFailure
   ## @param bucketInitJob.annotations Additional annotations for the bucket initialization job
+  ## To run the job as a Helm hook, set:
+  ##   annotations:
+  ##     helm.sh/hook: post-install,post-upgrade
+  ##     helm.sh/hook-delete-policy: before-hook-creation
   annotations: {}
+  ## @param bucketInitJob.podLabels Additional labels for the bucket initialization job pods
+  podLabels: {}
   ## @param bucketInitJob.podAnnotations Additional annotations for the bucket initialization job pods
   podAnnotations: {}
   ## @param bucketInitJob.resources Resource requests and limits for the bucket initialization job


### PR DESCRIPTION
## Summary

Align the bucket-init Job template with the Deployment template and fix upstream sync regressions:

- **`bucketInitJob.podLabels`** — inject custom labels into the job's pod spec (needed for ArgoCD / Istio sidecar control)
- **`commonLabels` propagation** — pod template now uses `minio.labels` instead of `minio.selectorLabels`, so `commonLabels` are propagated to pods (needed for Kyverno/OPA policies)
- **`serviceAccountName`** — the job now uses the chart's ServiceAccount (needed for IRSA/Workload Identity)
- **`priorityClassName`** — support priority class on the job pods
- **Fix Job name regression** — upstream sync reverted `bucket-init` back to `post-job`, restored to `bucket-init`
- **Remove dead `postJob` values** — unused `postJob` section removed, Helm hook usage documented as a comment under `bucketInitJob.annotations`

## References

- [ENT-3741](https://linear.app/gitguardian/issue/ENT-3741/helm-template-gap-podlabels-for-bucketinitjob-not-rendered-in-loki) — Helm template gap: podLabels for bucketInitJob not rendered (Richemont / ArgoCD)

## Test plan

- [x] `helm unittest charts/minio/` — all 26 tests pass
- [x] `helm lint charts/minio/` — no errors
- [ ] Verify with ArgoCD deployment that podLabels are rendered in the job pod spec