### PR TITLE
feat(minio): propagate global.* values to Deployment and bucket-init Job

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -128,3 +128,120 @@ Returns MinIO serviceAccount name
         {{ default "default" .Values.serviceAccount.name }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Merge global.podLabels with a component-level podLabels map.
+Component-level values win over global values on conflict.
+Usage: {{ include "minio.podLabels" (dict "local" .Values.podLabels "context" $) }}
+*/}}
+{{- define "minio.podLabels" -}}
+{{- $global := (.context.Values.global).podLabels | default dict -}}
+{{- $local := .local | default dict -}}
+{{- $merged := merge (deepCopy $local) $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Merge global.podAnnotations with a component-level podAnnotations map.
+Component-level values win over global values on conflict.
+Usage: {{ include "minio.podAnnotations" (dict "local" .Values.podAnnotations "context" $) }}
+*/}}
+{{- define "minio.podAnnotations" -}}
+{{- $global := (.context.Values.global).podAnnotations | default dict -}}
+{{- $local := .local | default dict -}}
+{{- $merged := merge (deepCopy $local) $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return nodeSelector: component-level value if set, otherwise global.nodeSelector.
+Usage: {{ include "minio.nodeSelector" (dict "local" .Values.nodeSelector "context" $) }}
+*/}}
+{{- define "minio.nodeSelector" -}}
+{{- $global := (.context.Values.global).nodeSelector | default dict -}}
+{{- $local := .local | default dict -}}
+{{- if $local -}}
+{{- toYaml $local }}
+{{- else if $global -}}
+{{- toYaml $global }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concat component-level tolerations with global.tolerations.
+Usage: {{ include "minio.tolerations" (dict "local" .Values.tolerations "context" $) }}
+*/}}
+{{- define "minio.tolerations" -}}
+{{- $global := (.context.Values.global).tolerations | default list -}}
+{{- $local := .local | default list -}}
+{{- $merged := concat $local $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concat component-level extraVolumes with global.extraVolumes.
+Usage: {{ include "minio.extraVolumes" (dict "local" .Values.extraVolumes "context" $) }}
+*/}}
+{{- define "minio.extraVolumes" -}}
+{{- $global := (.context.Values.global).extraVolumes | default list -}}
+{{- $local := .local | default list -}}
+{{- $merged := concat $local $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concat component-level extraVolumeMounts with global.extraVolumeMounts.
+Usage: {{ include "minio.extraVolumeMounts" (dict "local" .Values.extraVolumeMounts "context" $) }}
+*/}}
+{{- define "minio.extraVolumeMounts" -}}
+{{- $global := (.context.Values.global).extraVolumeMounts | default list -}}
+{{- $local := .local | default list -}}
+{{- $merged := concat $local $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concat component-level env vars with global.envVars.
+Usage: {{ include "minio.envVars" (dict "local" .Values.config.extraEnvVars "context" $) }}
+*/}}
+{{- define "minio.envVars" -}}
+{{- $global := (.context.Values.global).envVars | default list -}}
+{{- $local := .local | default list -}}
+{{- $merged := concat $local $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return global.envFrom list (no component-level equivalent in this chart).
+Usage: {{ include "minio.envFrom" $ }}
+*/}}
+{{- define "minio.envFrom" -}}
+{{- $global := (.Values.global).envFrom | default list -}}
+{{- if $global -}}
+{{- toYaml $global }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return imagePullPolicy: image.imagePullPolicy if set, otherwise global.image.imagePullPolicy.
+Fallback order matches cloudpirates.imagePullPolicy ("Always") for consistency with
+the rest of the library chart.
+Usage: {{ include "minio.imagePullPolicy" $ }}
+*/}}
+{{- define "minio.imagePullPolicy" -}}
+{{- $global := ((.Values.global).image).imagePullPolicy -}}
+{{- $local := .Values.image.imagePullPolicy -}}
+{{- $local | default $global | default "Always" -}}
+{{- end -}}

--- a/charts/minio/templates/bucket-init-job.yaml
+++ b/charts/minio/templates/bucket-init-job.yaml
@@ -22,12 +22,12 @@ spec:
       labels:
         {{- include "minio.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucket-init
-        {{- with .Values.bucketInitJob.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "minio.podLabels" (dict "local" .Values.bucketInitJob.podLabels "context" $)) }}
+        {{- . | nindent 8 }}
         {{- end }}
-      {{- with .Values.bucketInitJob.podAnnotations }}
+      {{- with (include "minio.podAnnotations" (dict "local" .Values.bucketInitJob.podAnnotations "context" $)) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
     spec:
 {{- with (include "minio.imagePullSecrets" .) }}
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: bucket-init
           image: {{ include "minio.image" . }}
-          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          imagePullPolicy: {{ include "minio.imagePullPolicy" . }}
           command: ["/bin/sh", "/scripts/provision-buckets.sh"]
           env:
             - name: MINIO_ROOT_USER
@@ -55,11 +55,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
                   key: {{ include "minio.rootPasswordKey" . }}
+            {{- with (include "minio.envVars" (dict "local" (list) "context" $)) }}
+            {{- . | nindent 12 }}
+            {{- end }}
+          {{- with (include "minio.envFrom" $) }}
+          envFrom:
+            {{- . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: scripts
               mountPath: /scripts
             - name: tmp
               mountPath: /tmp
+            {{- with (include "minio.extraVolumeMounts" (dict "local" (list) "context" $)) }}
+            {{- . | nindent 12 }}
+            {{- end }}
           {{- if .Values.bucketInitJob.resources }}
           resources: {{- toYaml .Values.bucketInitJob.resources | nindent 12 }}
           {{- end }}
@@ -74,16 +84,19 @@ spec:
             defaultMode: 0755
         - name: tmp
           emptyDir: {}
-      {{- with .Values.nodeSelector }}
+        {{- with (include "minio.extraVolumes" (dict "local" (list) "context" $)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+      {{- with (include "minio.nodeSelector" (dict "local" .Values.nodeSelector "context" $)) }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (include "minio.tolerations" (dict "local" .Values.tolerations "context" $)) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -18,15 +18,16 @@ spec:
       {{- include "minio.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- $annotations := merge .Values.podAnnotations .Values.commonAnnotations }}
+      {{- $globalPodAnnotations := (.Values.global).podAnnotations | default dict }}
+      {{- $annotations := mergeOverwrite (deepCopy $globalPodAnnotations) .Values.podAnnotations .Values.commonAnnotations }}
       {{- with $annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "minio.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "minio.podLabels" (dict "local" .Values.podLabels "context" $)) }}
+        {{- . | nindent 8 }}
         {{- end }}
     spec:
 {{- with (include "minio.imagePullSecrets" .) }}
@@ -45,7 +46,7 @@ spec:
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           {{- end }}
           image: {{ include "minio.image" . }}
-          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          imagePullPolicy: {{ include "minio.imagePullPolicy" . }}
           command: ["/bin/sh"]
           args:
             - -c
@@ -112,9 +113,13 @@ spec:
               value: {{ .Values.config.minioCompressionMimeTypes | quote }}
             {{- end }}
 
-            {{- with .Values.config.extraEnvVars }}
-            {{- toYaml . | nindent 12 }}
+            {{- with (include "minio.envVars" (dict "local" .Values.config.extraEnvVars "context" $)) }}
+            {{- . | nindent 12 }}
             {{- end }}
+          {{- with (include "minio.envFrom" $) }}
+          envFrom:
+            {{- . | nindent 12 }}
+          {{- end }}
           ports:
             - name: minio
               containerPort: {{ .Values.service.port }}
@@ -167,6 +172,9 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
             - name: tmp
               mountPath: /tmp
+            {{- with (include "minio.extraVolumeMounts" (dict "local" (list) "context" $)) }}
+            {{- . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}
@@ -181,15 +189,18 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
-      {{- with .Values.nodeSelector }}
+        {{- with (include "minio.extraVolumes" (dict "local" (list) "context" $)) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+      {{- with (include "minio.nodeSelector" (dict "local" .Values.nodeSelector "context" $)) }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (include "minio.tolerations" (dict "local" .Values.tolerations "context" $)) }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}

--- a/charts/minio/tests/globals_test.yaml
+++ b/charts/minio/tests/globals_test.yaml
@@ -1,0 +1,216 @@
+suite: test minio global.* propagation
+templates:
+  - deployment.yaml
+  - bucket-init-job.yaml
+  - bucket-init-configmap.yaml
+set:
+  image:
+    tag: RELEASE.2025-07-23T15-54-02Z@sha256:d249d1fb6966de4d8ad26c04754b545205ff15a62e4fd19ebd0f26fa5baacbc0
+  defaultBuckets: "test-bucket"
+tests:
+  - it: should propagate global.podLabels to Deployment pod template
+    template: deployment.yaml
+    set:
+      global:
+        podLabels:
+          sidecar.istio.io/inject: "false"
+          team: "platform"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.template.metadata.labels["team"]
+          value: "platform"
+
+  - it: should propagate global.podLabels to bucket-init Job pod template
+    template: bucket-init-job.yaml
+    set:
+      global:
+        podLabels:
+          sidecar.istio.io/inject: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+
+  - it: should prefer component-level podLabels over global.podLabels on conflict
+    template: deployment.yaml
+    set:
+      global:
+        podLabels:
+          env: "global-value"
+      podLabels:
+        env: "component-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: "component-value"
+
+  - it: should propagate global.podAnnotations to Deployment
+    template: deployment.yaml
+    set:
+      global:
+        podAnnotations:
+          prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should propagate global.podAnnotations to bucket-init Job
+    template: bucket-init-job.yaml
+    set:
+      global:
+        podAnnotations:
+          prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should use global.nodeSelector as fallback when component nodeSelector is empty
+    template: deployment.yaml
+    set:
+      global:
+        nodeSelector:
+          disk: "ssd"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disk
+          value: "ssd"
+
+  - it: should prefer component nodeSelector over global.nodeSelector
+    template: deployment.yaml
+    set:
+      global:
+        nodeSelector:
+          disk: "hdd"
+      nodeSelector:
+        disk: "nvme"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disk
+          value: "nvme"
+
+  - it: should concat global.tolerations with component tolerations
+    template: deployment.yaml
+    set:
+      global:
+        tolerations:
+          - key: "global-key"
+            operator: "Exists"
+      tolerations:
+        - key: "local-key"
+          operator: "Exists"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: "local-key"
+      - equal:
+          path: spec.template.spec.tolerations[1].key
+          value: "global-key"
+
+  - it: should inject global.envVars on Deployment container
+    template: deployment.yaml
+    set:
+      global:
+        envVars:
+          - name: GLOBAL_VAR
+            value: "global"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GLOBAL_VAR
+            value: "global"
+
+  - it: should inject global.envFrom on Deployment container
+    template: deployment.yaml
+    set:
+      global:
+        envFrom:
+          - configMapRef:
+              name: shared-config
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: "shared-config"
+
+  - it: should inject global.envFrom on bucket-init Job container
+    template: bucket-init-job.yaml
+    set:
+      global:
+        envFrom:
+          - configMapRef:
+              name: shared-config
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: "shared-config"
+
+  - it: should append global.extraVolumes to Deployment
+    template: deployment.yaml
+    set:
+      global:
+        extraVolumes:
+          - name: shared-ca
+            secret:
+              secretName: shared-ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: shared-ca
+            secret:
+              secretName: shared-ca-bundle
+
+  - it: should append global.extraVolumeMounts to Deployment container
+    template: deployment.yaml
+    set:
+      global:
+        extraVolumeMounts:
+          - name: shared-ca
+            mountPath: /etc/ssl/certs/ca-bundle.crt
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: shared-ca
+            mountPath: /etc/ssl/certs/ca-bundle.crt
+
+  - it: should use global.image.imagePullPolicy as fallback when image.imagePullPolicy is empty
+    template: deployment.yaml
+    set:
+      global:
+        image:
+          imagePullPolicy: "Never"
+      image:
+        imagePullPolicy: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Never"
+
+  - it: should prefer image.imagePullPolicy over global.image.imagePullPolicy
+    template: deployment.yaml
+    set:
+      global:
+        image:
+          imagePullPolicy: "Never"
+      image:
+        imagePullPolicy: "Always"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+
+  - it: should default imagePullPolicy to Always when neither global nor component sets it
+    template: deployment.yaml
+    set:
+      image:
+        imagePullPolicy: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
         "affinity": {

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "affinity": {
@@ -322,11 +322,43 @@
         "global": {
             "type": "object",
             "properties": {
+                "envFrom": {
+                    "type": "array"
+                },
+                "envVars": {
+                    "type": "array"
+                },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "imagePullPolicy": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },
                 "imageRegistry": {
                     "type": "string"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
                 }
             }
         },

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -4,6 +4,25 @@ global:
   imageRegistry: ""
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   imagePullSecrets: []
+  ## @param global.image.imagePullPolicy Fallback image pull policy when image.imagePullPolicy is not set
+  image:
+    imagePullPolicy: ""
+  ## @param global.podLabels Labels merged into the Deployment and bucket-init Job pod templates (component-level podLabels win on conflict)
+  podLabels: {}
+  ## @param global.podAnnotations Annotations merged into the Deployment and bucket-init Job pod templates (component-level podAnnotations win on conflict)
+  podAnnotations: {}
+  ## @param global.nodeSelector Fallback nodeSelector applied when component-level nodeSelector is unset
+  nodeSelector: {}
+  ## @param global.tolerations Tolerations concatenated with component-level tolerations
+  tolerations: []
+  ## @param global.envVars Environment variables concatenated to all containers' env (after config.extraEnvVars)
+  envVars: []
+  ## @param global.envFrom envFrom sources injected in all containers
+  envFrom: []
+  ## @param global.extraVolumes Extra volumes added to pod specs (Deployment and bucket-init Job)
+  extraVolumes: []
+  ## @param global.extraVolumeMounts Extra volume mounts added to all containers
+  extraVolumeMounts: []
 
 ## @section Common parameters
 ## @param nameOverride String to partially override minio.fullname


### PR DESCRIPTION
## Summary

Aligns the MinIO chart with the `global.*` convention introduced in [ENT-3039](https://linear.app/gitguardian/issue/ENT-3039) / ward-runs-app MR [!22055](https://gitlab.gitguardian.ovh/gg-code/prm/ward-runs-app/-/merge_requests/22055).

When used as a subchart (e.g. `loki-minio` in ward-runs-app), Helm auto-propagates parent `global.*` values but the MinIO templates didn't consume them — so setting `global.podLabels: {sidecar.istio.io/inject: "false"}` on the parent had no effect on the MinIO pods.

This PR makes the MinIO templates honor these globals, so configuration defined once on the parent chart applies consistently.

## Scope — additive only

`commonLabels` and `commonAnnotations` are **kept as-is** to preserve upstream sync compatibility with CloudPirates. No breaking changes.

## Values added under `global.*`

| Value | Behavior | Applied on |
|---|---|---|
| `global.image.imagePullPolicy` | Fallback when `image.imagePullPolicy` is empty | Deployment, bucket-init Job |
| `global.podLabels` | Merged into pod templates (component wins on conflict) | Deployment pod, bucket-init Job pod |
| `global.podAnnotations` | Merged into pod templates (component wins on conflict) | Deployment pod, bucket-init Job pod |
| `global.nodeSelector` | Fallback when component `nodeSelector` is empty | Deployment, bucket-init Job |
| `global.tolerations` | Concatenated with component `tolerations` | Deployment, bucket-init Job |
| `global.envVars` | Concatenated after `config.extraEnvVars` | Deployment container, bucket-init Job container |
| `global.envFrom` | New support (no component-level equivalent) | Deployment container, bucket-init Job container |
| `global.extraVolumes` | Appended to pod volumes | Deployment pod, bucket-init Job pod |
| `global.extraVolumeMounts` | Appended to container volumeMounts | Deployment container, bucket-init Job container |

## Implementation

- 9 new helpers in `_helpers.tpl` encapsulate the merge/concat logic (`minio.podLabels`, `minio.podAnnotations`, `minio.nodeSelector`, `minio.tolerations`, `minio.envVars`, `minio.envFrom`, `minio.extraVolumes`, `minio.extraVolumeMounts`, `minio.imagePullPolicy`)
- `templates/deployment.yaml` and `templates/bucket-init-job.yaml` updated to use them
- `values.yaml` and `values.schema.json` declare the new `global.*` keys (all default to empty)
- New test suite `tests/globals_test.yaml` — 16 tests covering all merge/override cases
- Chart version bumped `0.13.0` → `0.14.0`

## Test plan

- [x] `helm unittest charts/minio/` — all 42 tests pass (16 new + 26 pre-existing)
- [x] `helm lint charts/minio/` — no errors
- [ ] Verify in ward-runs-app that `global.podLabels` / `global.podAnnotations` set on parent are now propagated to loki-minio pods