### PR TITLE
feat(minio): propagate global.podLabels to Deployment and bucket-init Job

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -128,3 +128,17 @@ Returns MinIO serviceAccount name
         {{ default "default" .Values.serviceAccount.name }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Merge global.podLabels with a component-level podLabels map.
+Component-level values win over global values on conflict.
+Usage: {{ include "minio.podLabels" (dict "local" .Values.podLabels "context" $) }}
+*/}}
+{{- define "minio.podLabels" -}}
+{{- $global := (.context.Values.global).podLabels | default dict -}}
+{{- $local := .local | default dict -}}
+{{- $merged := merge (deepCopy $local) $global -}}
+{{- if $merged -}}
+{{- toYaml $merged }}
+{{- end -}}
+{{- end -}}

--- a/charts/minio/templates/bucket-init-job.yaml
+++ b/charts/minio/templates/bucket-init-job.yaml
@@ -22,8 +22,8 @@ spec:
       labels:
         {{- include "minio.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucket-init
-        {{- with .Values.bucketInitJob.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "minio.podLabels" (dict "local" .Values.bucketInitJob.podLabels "context" $)) }}
+        {{- . | nindent 8 }}
         {{- end }}
       {{- with .Values.bucketInitJob.podAnnotations }}
       annotations:

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
       {{- end }}
       labels:
         {{- include "minio.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- with (include "minio.podLabels" (dict "local" .Values.podLabels "context" $)) }}
+        {{- . | nindent 8 }}
         {{- end }}
     spec:
 {{- with (include "minio.imagePullSecrets" .) }}

--- a/charts/minio/tests/global-podlabels_test.yaml
+++ b/charts/minio/tests/global-podlabels_test.yaml
@@ -1,0 +1,68 @@
+suite: test minio global.podLabels propagation
+templates:
+  - deployment.yaml
+  - bucket-init-job.yaml
+  - bucket-init-configmap.yaml
+set:
+  image:
+    tag: RELEASE.2025-07-23T15-54-02Z@sha256:d249d1fb6966de4d8ad26c04754b545205ff15a62e4fd19ebd0f26fa5baacbc0
+  defaultBuckets: "test-bucket"
+tests:
+  - it: should propagate global.podLabels to Deployment pod template
+    template: deployment.yaml
+    set:
+      global:
+        podLabels:
+          sidecar.istio.io/inject: "false"
+          team: "platform"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.template.metadata.labels["team"]
+          value: "platform"
+
+  - it: should propagate global.podLabels to bucket-init Job pod template
+    template: bucket-init-job.yaml
+    set:
+      global:
+        podLabels:
+          sidecar.istio.io/inject: "false"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["sidecar.istio.io/inject"]
+          value: "false"
+
+  - it: should prefer component-level podLabels over global.podLabels on conflict (Deployment)
+    template: deployment.yaml
+    set:
+      global:
+        podLabels:
+          env: "global-value"
+      podLabels:
+        env: "component-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: "component-value"
+
+  - it: should prefer component-level bucketInitJob.podLabels over global.podLabels on conflict
+    template: bucket-init-job.yaml
+    set:
+      global:
+        podLabels:
+          env: "global-value"
+      bucketInitJob:
+        podLabels:
+          env: "component-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["env"]
+          value: "component-value"
+
+  - it: should not add pod labels when neither global nor component set them
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["env"]

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -327,6 +327,9 @@
                 },
                 "imageRegistry": {
                     "type": "string"
+                },
+                "podLabels": {
+                    "type": "object"
                 }
             }
         },

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -4,6 +4,8 @@ global:
   imageRegistry: ""
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   imagePullSecrets: []
+  ## @param global.podLabels Labels merged into the Deployment and bucket-init Job pod templates. Useful when the chart is used as a subchart and the parent sets pod labels globally. Component-level `podLabels` / `bucketInitJob.podLabels` win on conflict.
+  podLabels: {}
 
 ## @section Common parameters
 ## @param nameOverride String to partially override minio.fullname


### PR DESCRIPTION
## Summary

Closes [ENT-3801](https://linear.app/gitguardian/issue/ENT-3801/unit-test-to-check-all-pods-had-globalpodlabels).

When the MinIO chart is used as a subchart (e.g. `loki-minio` in ward-runs-app), Helm auto-propagates the parent's `global.*` values, but the MinIO templates didn't consume `global.podLabels`. Setting `global.podLabels: {sidecar.istio.io/inject: "false"}` on the parent had **no effect** on the MinIO pods.

This PR makes both the Deployment and the bucket-init Job pod templates honor `global.podLabels`, and adds unit tests covering all merge/override cases.

## Scope — minimal, additive

Only `global.podLabels` is added. `commonLabels` and `commonAnnotations` are unchanged to preserve upstream sync compatibility with CloudPirates.

## Changes

| File | Change |
|---|---|
| `templates/_helpers.tpl` | New helper `minio.podLabels` merges `global.podLabels` with component-level `podLabels` (component wins on conflict) |
| `templates/deployment.yaml` | Pod template uses `minio.podLabels` helper |
| `templates/bucket-init-job.yaml` | Pod template uses `minio.podLabels` helper |
| `values.yaml` | Declares `global.podLabels: {}` with doc |
| `values.schema.json` | Regenerated |
| `tests/global-podlabels_test.yaml` | New suite — 5 tests (propagation to both pods, override, absence) |
| `Chart.yaml` | `0.13.0` → `0.14.0` |

## Test plan

- [x] `helm unittest charts/minio/` — all 31 tests pass (5 new + 26 pre-existing)
- [x] `helm lint charts/minio/` — no errors
- [ ] Verify in ward-runs-app that `global.podLabels` set on parent is now propagated to `loki-minio` Deployment and bucket-init Job pods