### PR TITLE
feat(clickhouse): add standalone ClickHouse chart + Keeper (ENT-3986)

### DIFF
--- a/charts/clickhouse/.helmignore
+++ b/charts/clickhouse/.helmignore
@@ -1,0 +1,2 @@
+artifacthub-repo.yaml
+tests/

--- a/charts/clickhouse/CHANGELOG.md
+++ b/charts/clickhouse/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [0.1.0]
+
+### Added
+
+- Initial release of the standalone ClickHouse Helm chart
+- StatefulSet deployment using official `clickhouse/clickhouse-server` image
+- Configurable `config.xml` and `users.xml` via ConfigMaps
+- Persistent storage via PVC with configurable size and storage class
+- HTTP (8123) and TCP/native (9000) service ports
+- Headless service for StatefulSet DNS
+- Optional Prometheus metrics sidecar with ServiceMonitor support
+- Optional Ingress and Gateway API HTTPRoute resources
+- Optional ServiceAccount creation
+- Liveness, readiness, and startup probes via ClickHouse `/ping` endpoint
+- Support for init SQL scripts via ConfigMap
+- `extraObjects`, `extraEnvVars`, `extraVolumes`, `extraVolumeMounts` escape hatches
+- Auto-generated credentials secret with connection URI
+- Pod and container security context defaults
+- `persistentVolumeClaimRetentionPolicy` support

--- a/charts/clickhouse/CHANGELOG.md
+++ b/charts/clickhouse/CHANGELOG.md
@@ -9,6 +9,7 @@
 - ClickHouse wired to Keeper when enabled: `<zookeeper>`, single-shard `<remote_servers>` cluster across the replicas, per-pod `<macros>` (`{shard}`/`{replica}`), and `<interserver_http_credentials>` so `ReplicatedMergeTree` / `ON CLUSTER` work out of the box
 - `app.kubernetes.io/component` (`server` / `keeper`) labels to isolate ClickHouse and Keeper pods/services
 - `clusterDomain` and `cluster.name` values
+- `config.extraConfig` and `config.extraUsersConfig` are now rendered with `tpl`, so Helm template expressions (e.g. `{{ .Release.Namespace }}`) can be used — useful for per-release S3 prefixes
 
 ## [0.1.0]
 

--- a/charts/clickhouse/CHANGELOG.md
+++ b/charts/clickhouse/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.0]
+
+### Added
+
+- ClickHouse Keeper support (Raft-based coordination, ZooKeeper replacement) as a dedicated, opt-in StatefulSet (`keeper.enabled`)
+- Keeper quorum templates: StatefulSet (per-pod `server_id` derived from the pod ordinal), Raft config ConfigMap, headless service (stable per-member DNS), client service (`9181`), optional PodDisruptionBudget
+- ClickHouse wired to Keeper when enabled: `<zookeeper>`, single-shard `<remote_servers>` cluster across the replicas, per-pod `<macros>` (`{shard}`/`{replica}`), and `<interserver_http_credentials>` so `ReplicatedMergeTree` / `ON CLUSTER` work out of the box
+- `app.kubernetes.io/component` (`server` / `keeper`) labels to isolate ClickHouse and Keeper pods/services
+- `clusterDomain` and `cluster.name` values
+
 ## [0.1.0]
 
 ### Added

--- a/charts/clickhouse/Chart.lock
+++ b/charts/clickhouse/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 2.2.0
+digest: sha256:a2168dfa04b6fbeb8ab278d891670dd5d27c51366c36853e156f07479720cefe
+generated: "2026-03-30T07:55:43.090874+02:00"

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -1,0 +1,49 @@
+apiVersion: v2
+name: clickhouse
+description: The Open-Source, High Performance Columnar OLAP Database Management System
+type: application
+version: 0.1.0
+appVersion: "25.3.14.14"
+keywords:
+  - clickhouse
+  - database
+  - olap
+  - analytics
+  - columnar
+home: https://clickhouse.com
+sources:
+  - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/clickhouse
+  - https://github.com/ClickHouse/ClickHouse
+maintainers:
+  - name: CloudPirates GmbH & Co. KG
+    email: hello@cloudpirates.io
+    url: https://www.cloudpirates.io
+dependencies:
+  - name: common
+    version: "2.2.x"
+    repository: oci://registry-1.docker.io/cloudpirates
+icon: https://a.storyblok.com/f/143071/512x512/7be3e97a51/clickhouse-logo.svg
+annotations:
+  license: Apache-2.0
+  artifacthub.io/category: database
+  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/signKey: |
+    fingerprint: 6917f1a88c122cbb1de5aa55457752135bdcf95a
+    url: https://raw.githubusercontent.com/CloudPirates-io/helm-charts/refs/heads/main/cosign.pub
+  artifacthub.io/links: |
+    - name: ClickHouse
+      url: https://clickhouse.com
+    - name: Helm Chart
+      url: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/clickhouse
+    - name: Application
+      url: https://github.com/ClickHouse/ClickHouse
+    - name: Docker Image
+      url: https://hub.docker.com/r/clickhouse/clickhouse-server
+    - name: Maintainer CloudPirates
+      url: https://www.cloudpirates.io
+  artifacthub.io/changes: |-
+    - kind: added
+      description: "Initial release of the ClickHouse chart"
+      links:
+        - name: "Changelog"
+          url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/clickhouse/CHANGELOG.md"

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: The Open-Source, High Performance Columnar OLAP Database Management System
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "25.3.14.14"
 keywords:
   - clickhouse

--- a/charts/clickhouse/artifacthub-repo.yml
+++ b/charts/clickhouse/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: XXXXXXXX

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clickhouse.name" -}}
+{{- include "cloudpirates.name" . -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clickhouse.fullname" -}}
+{{- include "cloudpirates.fullname" . -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clickhouse.chart" -}}
+{{- include "cloudpirates.chart" . -}}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clickhouse.labels" -}}
+{{- include "cloudpirates.labels" . -}}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "clickhouse.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clickhouse.selectorLabels" -}}
+{{- include "cloudpirates.selectorLabels" . -}}
+{{- end }}
+
+{{/*
+Return the proper ClickHouse image name
+*/}}
+{{- define "clickhouse.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Return ClickHouse credentials secret name
+*/}}
+{{- define "clickhouse.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+    {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.auth.existingSecret "context" .) -}}
+{{- else -}}
+    {{- include "clickhouse.fullname" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return ClickHouse admin password key
+*/}}
+{{- define "clickhouse.passwordKey" -}}
+{{- if .Values.auth.existingSecret -}}
+    {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.auth.secretKeys.passwordKey "context" .) | default "clickhouse-password" -}}
+{{- else -}}
+clickhouse-password
+{{- end -}}
+{{- end }}
+
+{{/*
+Return ClickHouse configuration ConfigMap name
+*/}}
+{{- define "clickhouse.configmapName" -}}
+{{- if .Values.config.existingConfigmap -}}
+    {{- .Values.config.existingConfigmap -}}
+{{- else -}}
+    {{- printf "%s-config" (include "clickhouse.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return ClickHouse users configuration ConfigMap name
+*/}}
+{{- define "clickhouse.usersConfigmapName" -}}
+{{- if .Values.config.existingUsersConfigmap -}}
+    {{- .Values.config.existingUsersConfigmap -}}
+{{- else -}}
+    {{- printf "%s-users" (include "clickhouse.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return ClickHouse init scripts ConfigMap name
+*/}}
+{{- define "clickhouse.initdb.scriptsCM" -}}
+{{- if .Values.initdb.scriptsConfigMap -}}
+    {{- printf "%s" (tpl .Values.initdb.scriptsConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-init-scripts" (include "clickhouse.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "clickhouse.imagePullSecrets" -}}
+{{ include "cloudpirates.images.renderPullSecrets" (dict "images" (list .Values.image) "context" .) }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "clickhouse.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "clickhouse.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -123,3 +123,52 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+ClickHouse Keeper fully qualified name
+*/}}
+{{- define "clickhouse.keeper.fullname" -}}
+{{- printf "%s-keeper" (include "clickhouse.fullname" .) -}}
+{{- end }}
+
+{{/*
+ClickHouse Keeper client service name (targeted by ClickHouse <zookeeper>)
+*/}}
+{{- define "clickhouse.keeper.serviceName" -}}
+{{- include "clickhouse.keeper.fullname" . -}}
+{{- end }}
+
+{{/*
+ClickHouse Keeper headless service name (stable per-pod DNS for the Raft quorum)
+*/}}
+{{- define "clickhouse.keeper.headlessServiceName" -}}
+{{- printf "%s-headless" (include "clickhouse.keeper.fullname" .) -}}
+{{- end }}
+
+{{/*
+ClickHouse Keeper config ConfigMap name
+*/}}
+{{- define "clickhouse.keeper.configmapName" -}}
+{{- printf "%s-config" (include "clickhouse.keeper.fullname" .) -}}
+{{- end }}
+
+{{/*
+Cluster domain used to build stable in-cluster DNS names.
+*/}}
+{{- define "clickhouse.clusterDomain" -}}
+{{- .Values.clusterDomain | default "cluster.local" -}}
+{{- end }}
+
+{{/*
+Return the proper ClickHouse Keeper image name
+*/}}
+{{- define "clickhouse.keeper.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.keeper.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names for the Keeper image
+*/}}
+{{- define "clickhouse.keeper.imagePullSecrets" -}}
+{{ include "cloudpirates.images.renderPullSecrets" (dict "images" (list .Values.keeper.image) "context" .) }}
+{{- end -}}

--- a/charts/clickhouse/templates/configmap.yaml
+++ b/charts/clickhouse/templates/configmap.yaml
@@ -1,0 +1,71 @@
+{{- if not .Values.config.existingConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse.configmapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+data:
+  kubernetes.xml: |
+    <?xml version="1.0"?>
+    <clickhouse>
+      <listen_host>{{ .Values.config.listenHost }}</listen_host>
+      <http_port>{{ .Values.service.httpPort }}</http_port>
+      <tcp_port>{{ .Values.service.tcpPort }}</tcp_port>
+      <max_connections>{{ .Values.config.maxConnections }}</max_connections>
+      <max_concurrent_queries>{{ .Values.config.maxConcurrentQueries }}</max_concurrent_queries>
+      <timezone>{{ .Values.config.timezone }}</timezone>
+      <logger>
+        <level>{{ .Values.config.logLevel }}</level>
+        <console>1</console>
+      </logger>
+      {{- if .Values.config.extraConfig }}
+      {{ .Values.config.extraConfig | nindent 6 }}
+      {{- end }}
+    </clickhouse>
+{{- end }}
+---
+{{- if not .Values.config.existingUsersConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse.usersConfigmapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+data:
+  kubernetes.xml: |
+    <?xml version="1.0"?>
+    <clickhouse>
+      <users>
+        <{{ .Values.auth.username }}>
+          <password replace="replace" from_env="CLICKHOUSE_PASSWORD"></password>
+          <networks>
+            <ip>::/0</ip>
+          </networks>
+          <profile>default</profile>
+          <quota>default</quota>
+          <access_management>1</access_management>
+        </{{ .Values.auth.username }}>
+      </users>
+      {{- if gt (.Values.config.maxMemoryUsage | int) 0 }}
+      <profiles>
+        <default>
+          <max_memory_usage>{{ .Values.config.maxMemoryUsage }}</max_memory_usage>
+        </default>
+      </profiles>
+      {{- end }}
+      {{- if .Values.config.extraUsersConfig }}
+      {{ .Values.config.extraUsersConfig | nindent 6 }}
+      {{- end }}
+    </clickhouse>
+{{- end }}

--- a/charts/clickhouse/templates/configmap.yaml
+++ b/charts/clickhouse/templates/configmap.yaml
@@ -24,6 +24,45 @@ data:
         <level>{{ .Values.config.logLevel }}</level>
         <console>1</console>
       </logger>
+      {{- if .Values.keeper.enabled }}
+      <interserver_http_port>{{ .Values.config.interserverHttpPort }}</interserver_http_port>
+      <interserver_http_credentials>
+        <user>{{ .Values.auth.username }}</user>
+        <password from_env="CLICKHOUSE_PASSWORD"></password>
+      </interserver_http_credentials>
+      <zookeeper>
+        <node>
+          <host>{{ include "clickhouse.keeper.serviceName" . }}</host>
+          <port>{{ .Values.keeper.ports.client }}</port>
+        </node>
+      </zookeeper>
+      <remote_servers>
+        <{{ .Values.cluster.name }}>
+          <shard>
+            <internal_replication>true</internal_replication>
+            {{- $fullname := include "clickhouse.fullname" . }}
+            {{- $headless := printf "%s-headless" (include "clickhouse.fullname" .) }}
+            {{- $ns := .Release.Namespace }}
+            {{- $domain := include "clickhouse.clusterDomain" . }}
+            {{- $tcpPort := .Values.service.tcpPort }}
+            {{- $user := .Values.auth.username }}
+            {{- range $i := until (int .Values.replicaCount) }}
+            <replica>
+              <host>{{ printf "%s-%d.%s.%s.svc.%s" $fullname $i $headless $ns $domain }}</host>
+              <port>{{ $tcpPort }}</port>
+              <user>{{ $user }}</user>
+              <password from_env="CLICKHOUSE_PASSWORD"></password>
+            </replica>
+            {{- end }}
+          </shard>
+        </{{ .Values.cluster.name }}>
+      </remote_servers>
+      <macros>
+        <cluster>{{ .Values.cluster.name }}</cluster>
+        <shard>01</shard>
+        <replica from_env="POD_NAME"></replica>
+      </macros>
+      {{- end }}
       {{- if .Values.config.extraConfig }}
       {{ .Values.config.extraConfig | nindent 6 }}
       {{- end }}

--- a/charts/clickhouse/templates/configmap.yaml
+++ b/charts/clickhouse/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
       </macros>
       {{- end }}
       {{- if .Values.config.extraConfig }}
-      {{ .Values.config.extraConfig | nindent 6 }}
+      {{ tpl .Values.config.extraConfig . | nindent 6 }}
       {{- end }}
     </clickhouse>
 {{- end }}
@@ -104,7 +104,7 @@ data:
       </profiles>
       {{- end }}
       {{- if .Values.config.extraUsersConfig }}
-      {{ .Values.config.extraUsersConfig | nindent 6 }}
+      {{ tpl .Values.config.extraUsersConfig . | nindent 6 }}
       {{- end }}
     </clickhouse>
 {{- end }}

--- a/charts/clickhouse/templates/extraobjects.yaml
+++ b/charts/clickhouse/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/clickhouse/templates/httproute.yaml
+++ b/charts/clickhouse/templates/httproute.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.gatewayAPI.httpRoute.enabled -}}
+{{- $fullName := include "clickhouse.fullname" . -}}
+{{- $svcPort := .Values.service.httpPort -}}
+{{- $httpRoute := .Values.gatewayAPI.httpRoute -}}
+{{- $hostnames := $httpRoute.hostnames -}}
+{{- if not $hostnames }}
+{{- $hostnames = list -}}
+{{- range .Values.ingress.hosts -}}
+{{- $hostnames = append $hostnames .host -}}
+{{- end -}}
+{{- end -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range $httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+  {{- if $hostnames }}
+  hostnames:
+    {{- range $hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if $httpRoute.rules }}
+    {{- range $httpRoute.rules }}
+    - {{- if .matches }}
+      matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type }}
+            value: {{ .path.value }}
+        {{- end }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
+    {{- range .paths }}
+    - matches:
+        - path:
+            type: {{ if eq .pathType "Exact" }}Exact{{ else }}PathPrefix{{ end }}
+            value: {{ .path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/ingress.yaml
+++ b/charts/clickhouse/templates/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "clickhouse.fullname" . -}}
+{{- $svcPort := .Values.service.httpPort -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/init-scripts-configmap.yaml
+++ b/charts/clickhouse/templates/init-scripts-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.initdb.scripts (not .Values.initdb.scriptsConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse.initdb.scriptsCM" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $value := .Values.initdb.scripts }}
+  {{ $key }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/keeper/configmap.yaml
+++ b/charts/clickhouse/templates/keeper/configmap.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.keeper.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse.keeper.configmapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+data:
+  keeper_config.xml: |
+    <?xml version="1.0"?>
+    <clickhouse>
+      <listen_host>{{ .Values.config.listenHost }}</listen_host>
+      <logger>
+        <level>{{ .Values.config.logLevel }}</level>
+        <console>1</console>
+      </logger>
+      <max_connections>4096</max_connections>
+      <keeper_server>
+        <tcp_port>{{ .Values.keeper.ports.client }}</tcp_port>
+        <!-- server_id is injected per-pod from the StatefulSet ordinal (see statefulset command) -->
+        <server_id from_env="KEEPER_SERVER_ID"></server_id>
+        <log_storage_path>/var/lib/clickhouse-keeper/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse-keeper/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+          <operation_timeout_ms>10000</operation_timeout_ms>
+          <session_timeout_ms>30000</session_timeout_ms>
+          <raft_logs_level>{{ .Values.keeper.raftLogsLevel }}</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+          {{- $fullname := include "clickhouse.keeper.fullname" . }}
+          {{- $headless := include "clickhouse.keeper.headlessServiceName" . }}
+          {{- $ns := .Release.Namespace }}
+          {{- $domain := include "clickhouse.clusterDomain" . }}
+          {{- $raftPort := .Values.keeper.ports.raft }}
+          {{- range $i := until (int .Values.keeper.replicaCount) }}
+          <server>
+            <id>{{ add $i 1 }}</id>
+            <hostname>{{ printf "%s-%d.%s.%s.svc.%s" $fullname $i $headless $ns $domain }}</hostname>
+            <port>{{ $raftPort }}</port>
+          </server>
+          {{- end }}
+        </raft_configuration>
+      </keeper_server>
+      {{- if .Values.keeper.extraConfig }}
+      {{ .Values.keeper.extraConfig | nindent 6 }}
+      {{- end }}
+    </clickhouse>
+{{- end }}

--- a/charts/clickhouse/templates/keeper/headless-service.yaml
+++ b/charts/clickhouse/templates/keeper/headless-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.keeper.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse.keeper.headlessServiceName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # Raft members must resolve each other (by stable per-pod DNS) before they are Ready.
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.keeper.ports.client }}
+      targetPort: client
+      protocol: TCP
+      name: client
+    - port: {{ .Values.keeper.ports.raft }}
+      targetPort: raft
+      protocol: TCP
+      name: raft
+  selector:
+    {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+{{- end }}

--- a/charts/clickhouse/templates/keeper/pdb.yaml
+++ b/charts/clickhouse/templates/keeper/pdb.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keeper.enabled .Values.keeper.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clickhouse.keeper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.keeper.pdb.minAvailable }}
+  minAvailable: {{ .Values.keeper.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.keeper.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.keeper.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keeper
+{{- end }}

--- a/charts/clickhouse/templates/keeper/service.yaml
+++ b/charts/clickhouse/templates/keeper/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.keeper.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse.keeper.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+  {{- $annotations := merge .Values.keeper.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.keeper.service.type }}
+  ports:
+    - port: {{ .Values.keeper.ports.client }}
+      targetPort: client
+      protocol: TCP
+      name: client
+  selector:
+    {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+{{- end }}

--- a/charts/clickhouse/templates/keeper/statefulset.yaml
+++ b/charts/clickhouse/templates/keeper/statefulset.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.keeper.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clickhouse.keeper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keeper
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.keeper.replicaCount }}
+  serviceName: {{ include "clickhouse.keeper.headlessServiceName" . }}
+  podManagementPolicy: {{ .Values.keeper.podManagementPolicy }}
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "clickhouse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keeper
+  template:
+    metadata:
+      {{- $annotations := merge .Values.keeper.podAnnotations .Values.commonAnnotations }}
+      {{- with $annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clickhouse.labels" . | nindent 8 }}
+        app.kubernetes.io/component: keeper
+        {{- with .Values.keeper.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "clickhouse.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with (include "clickhouse.keeper.imagePullSecrets" .) }}
+{{- . | nindent 6 }}
+{{- end }}
+      securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      enableServiceLinks: {{ .Values.global.enableServiceLinks }}
+      containers:
+        - name: keeper
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
+          image: {{ include "clickhouse.keeper.image" . }}
+          imagePullPolicy: {{ .Values.keeper.image.imagePullPolicy }}
+          # ClickHouse Keeper needs a unique server_id per Raft member. Derive it
+          # from the StatefulSet pod ordinal (1-based to match raft_configuration <id>).
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              ORDINAL="${HOSTNAME##*-}"
+              export KEEPER_SERVER_ID="$((ORDINAL + 1))"
+              exec /usr/bin/clickhouse-keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
+          ports:
+            - name: client
+              containerPort: {{ .Values.keeper.ports.client }}
+              protocol: TCP
+            - name: raft
+              containerPort: {{ .Values.keeper.ports.raft }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.keeper.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/clickhouse-keeper/keeper_config.xml
+              subPath: keeper_config.xml
+            - name: {{ .Values.keeper.persistence.volumeName }}
+              mountPath: /var/lib/clickhouse-keeper
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.keeper.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "clickhouse.keeper.configmapName" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if not .Values.keeper.persistence.enabled }}
+        - name: {{ .Values.keeper.persistence.volumeName }}
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.keeper.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.keeper.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keeper.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keeper.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.keeper.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.keeper.persistence.volumeName }}
+      {{- with .Values.keeper.persistence.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      accessModes:
+        {{- range .Values.keeper.persistence.accessModes }}
+        - {{ . | quote }}
+        {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.keeper.persistence.size | quote }}
+      {{- if .Values.keeper.persistence.storageClass }}
+      {{- if (eq "-" .Values.keeper.persistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.keeper.persistence.storageClass | quote }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/secret.yaml
+++ b/charts/clickhouse/templates/secret.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clickhouse.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "clickhouse.fullname" .)) }}
+  {{- $existingPassword := "" }}
+  {{- if and $existingSecret $existingSecret.data }}
+    {{- $existingPassword = index $existingSecret.data "clickhouse-password" }}
+  {{- end }}
+  {{- $password := $existingPassword | default (.Values.auth.password | default (randAlphaNum 32) | b64enc) }}
+  {{- $host := printf "%s.%s.svc" (include "clickhouse.fullname" .) .Release.Namespace }}
+  {{- $tcpPort := .Values.service.tcpPort | toString }}
+  {{- $httpPort := .Values.service.httpPort | toString }}
+  {{- $username := .Values.auth.username }}
+  {{- $database := .Values.auth.database }}
+  clickhouse-password: {{ $password | quote }}
+  host: {{ $host | b64enc | quote }}
+  tcp-port: {{ $tcpPort | b64enc | quote }}
+  http-port: {{ $httpPort | b64enc | quote }}
+  username: {{ $username | b64enc | quote }}
+  database: {{ $database | b64enc | quote }}
+  uri: {{ printf "clickhouse://%s:%s@%s:%s/%s" $username ($password | b64dec) $host $tcpPort $database | b64enc | quote }}
+{{- end }}

--- a/charts/clickhouse/templates/service-metrics.yaml
+++ b/charts/clickhouse/templates/service-metrics.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/clickhouse/templates/service.yaml
+++ b/charts/clickhouse/templates/service.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) (not (empty .Values.service.externalTrafficPolicy)) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.tcpPort }}
+      targetPort: tcp
+      {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      protocol: TCP
+      name: tcp
+  selector:
+    {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse.fullname" . }}-headless
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.tcpPort }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    {{- include "clickhouse.selectorLabels" . | nindent 4 }}

--- a/charts/clickhouse/templates/service.yaml
+++ b/charts/clickhouse/templates/service.yaml
@@ -32,6 +32,7 @@ spec:
       name: tcp
   selector:
     {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 ---
 apiVersion: v1
 kind: Service
@@ -57,5 +58,12 @@ spec:
       targetPort: tcp
       protocol: TCP
       name: tcp
+    {{- if .Values.keeper.enabled }}
+    - port: {{ .Values.config.interserverHttpPort }}
+      targetPort: interserver
+      protocol: TCP
+      name: interserver
+    {{- end }}
   selector:
     {{- include "clickhouse.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/charts/clickhouse/templates/serviceaccount.yaml
+++ b/charts/clickhouse/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clickhouse.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/servicemonitor.yaml
+++ b/charts/clickhouse/templates/servicemonitor.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "clickhouse.fullname" . }}-metrics
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $annotations := merge .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ include "clickhouse.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/statefulset.yaml
+++ b/charts/clickhouse/templates/statefulset.yaml
@@ -1,0 +1,260 @@
+{{- $hasInitScripts := or .Values.initdb.scripts .Values.initdb.scriptsConfigMap -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clickhouse.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "clickhouse.annotations" . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "clickhouse.fullname" . }}-headless
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "clickhouse.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- $annotations := merge .Values.podAnnotations .Values.commonAnnotations }}
+      {{- with $annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "clickhouse.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "clickhouse.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with (include "clickhouse.imagePullSecrets" .) }}
+{{- . | nindent 6 }}
+{{- end }}
+      securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      enableServiceLinks: {{ .Values.global.enableServiceLinks }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
+          image: {{ include "clickhouse.image" . }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- if .Values.command }}
+          command: {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
+          env:
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clickhouse.secretName" . }}
+                  key: {{ include "clickhouse.passwordKey" . }}
+            - name: CLICKHOUSE_DB
+              value: {{ .Values.auth.database | quote }}
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.auth.username | quote }}
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+            {{- with .Values.extraEnvVars }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.httpPort }}
+              protocol: TCP
+            - name: tcp
+              containerPort: {{ .Values.service.tcpPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: {{ .Values.persistence.volumeName }}
+              mountPath: /var/lib/clickhouse
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d/kubernetes.xml
+              subPath: kubernetes.xml
+            - name: users-config
+              mountPath: /etc/clickhouse-server/users.d/kubernetes.xml
+              subPath: kubernetes.xml
+            - name: tmp
+              mountPath: /tmp
+            {{- if $hasInitScripts }}
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          env:
+            - name: CLICKHOUSE_USER
+              value: {{ .Values.auth.username | quote }}
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "clickhouse.secretName" . }}
+                  key: {{ include "clickhouse.passwordKey" . }}
+            - name: CLICKHOUSE_URL
+              value: "http://localhost:{{ .Values.service.httpPort }}/"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.service.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        {{- if not .Values.persistence.enabled }}
+        - name: {{ .Values.persistence.volumeName }}
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.persistence.existingClaim }}
+        - name: {{ .Values.persistence.volumeName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "clickhouse.configmapName" . }}
+        - name: users-config
+          configMap:
+            name: {{ include "clickhouse.usersConfigmapName" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if $hasInitScripts }}
+        - name: init-scripts
+          configMap:
+            name: {{ include "clickhouse.initdb.scriptsCM" . }}
+            defaultMode: 0755
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
+  {{- if not .Values.persistence.existingClaim }}
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.persistence.volumeName }}
+      {{- with $labels := merge (include "clickhouse.selectorLabels" . | fromYaml) .Values.persistence.labels .Values.podLabels }}
+      labels:
+        {{- toYaml $labels | nindent 8 }}
+      {{- end }}
+      {{- with .Values.persistence.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      accessModes:
+        {{- range .Values.persistence.accessModes }}
+        - {{ . | quote }}
+        {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+      {{- if .Values.persistence.storageClass }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.persistence.storageClass | quote }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/clickhouse/templates/statefulset.yaml
+++ b/charts/clickhouse/templates/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
   selector:
     matchLabels:
       {{- include "clickhouse.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
   template:
     metadata:
       {{- $annotations := merge .Values.podAnnotations .Values.commonAnnotations }}
@@ -26,6 +27,7 @@ spec:
       {{- end }}
       labels:
         {{- include "clickhouse.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -68,6 +70,10 @@ spec:
               value: {{ .Values.auth.username | quote }}
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- with .Values.extraEnvVars }}
 {{ toYaml . | indent 12 }}
             {{- end }}
@@ -83,6 +89,11 @@ spec:
             - name: tcp
               containerPort: {{ .Values.service.tcpPort }}
               protocol: TCP
+            {{- if .Values.keeper.enabled }}
+            - name: interserver
+              containerPort: {{ .Values.config.interserverHttpPort }}
+              protocol: TCP
+            {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/clickhouse/tests/common-parameters_test.yaml
+++ b/charts/clickhouse/tests/common-parameters_test.yaml
@@ -1,0 +1,131 @@
+suite: test clickhouse common parameters
+templates:
+  - statefulset.yaml
+tests:
+  - it: should use default values when nothing is overridden
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-clickhouse
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: clickhouse
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should respect global.imageRegistry override
+    set:
+      global:
+        imageRegistry: "my-registry.com"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^my-registry.com/clickhouse/clickhouse-server:.*"
+
+  - it: should respect global.imagePullSecrets
+    set:
+      global:
+        imagePullSecrets:
+          - name: my-secret-1
+          - name: my-secret-2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: my-secret-1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: my-secret-2
+
+  - it: should respect nameOverride
+    set:
+      nameOverride: "custom-name"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-custom-name
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: custom-name
+
+  - it: should respect fullnameOverride
+    set:
+      fullnameOverride: "completely-custom-name"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: completely-custom-name
+
+  - it: should add commonLabels to all resources
+    set:
+      commonLabels:
+        environment: "test"
+        team: "platform"
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: test
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+  - it: should add commonAnnotations to all resources
+    set:
+      commonAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should respect image.imagePullPolicy override
+    set:
+      image:
+        imagePullPolicy: "IfNotPresent"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should set CLICKHOUSE_USER env var from values
+    set:
+      auth:
+        username: "myadmin"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_USER
+            value: "myadmin"
+
+  - it: should set CLICKHOUSE_DB env var from values
+    set:
+      auth:
+        database: "mydb"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_DB
+            value: "mydb"
+
+  - it: should set replicaCount
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should set the headless service name
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-clickhouse-headless

--- a/charts/clickhouse/tests/keeper_test.yaml
+++ b/charts/clickhouse/tests/keeper_test.yaml
@@ -1,0 +1,91 @@
+suite: test clickhouse keeper
+tests:
+  - it: should not render the Keeper StatefulSet by default
+    template: keeper/statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render Keeper services by default
+    template: keeper/service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not wire cluster config into ClickHouse by default
+    template: configmap.yaml
+    documentIndex: 0
+    asserts:
+      - notMatchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "<zookeeper>"
+      - notMatchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "<macros>"
+
+  - it: should render the Keeper StatefulSet when enabled
+    template: keeper/statefulset.yaml
+    set:
+      keeper.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-clickhouse-keeper
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-clickhouse-keeper-headless
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: keeper
+
+  - it: should list every Keeper replica in the Raft configuration
+    template: keeper/configmap.yaml
+    set:
+      keeper.enabled: true
+      keeper.replicaCount: 3
+    asserts:
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<id>1</id>"
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "<id>3</id>"
+      - matchRegex:
+          path: data["keeper_config.xml"]
+          pattern: "clickhouse-keeper-2\\.RELEASE-NAME-clickhouse-keeper-headless"
+
+  - it: should render the Keeper client service on port 9181 when enabled
+    template: keeper/service.yaml
+    set:
+      keeper.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 9181
+
+  - it: should wire zookeeper, remote_servers and macros into ClickHouse when enabled
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      keeper.enabled: true
+      replicaCount: 2
+    asserts:
+      - matchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "<zookeeper>"
+      - matchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "RELEASE-NAME-clickhouse-keeper"
+      - matchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "<replica from_env=\"POD_NAME\">"
+      - matchRegex:
+          path: data["kubernetes.xml"]
+          pattern: "clickhouse-1\\.RELEASE-NAME-clickhouse-headless"

--- a/charts/clickhouse/tests/secret_test.yaml
+++ b/charts/clickhouse/tests/secret_test.yaml
@@ -1,0 +1,43 @@
+suite: test clickhouse secret
+templates:
+  - secret.yaml
+tests:
+  - it: should create secret by default
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-clickhouse
+
+  - it: should not create secret when existingSecret is set
+    set:
+      auth:
+        existingSecret: "my-existing-secret"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use provided password when set
+    set:
+      auth:
+        password: "mysecretpassword"
+    asserts:
+      - equal:
+          path: data["clickhouse-password"]
+          value: bXlzZWNyZXRwYXNzd29yZA==
+
+  - it: should include host and port keys
+    asserts:
+      - isNotEmpty:
+          path: data.host
+      - isNotEmpty:
+          path: data["tcp-port"]
+      - isNotEmpty:
+          path: data["http-port"]
+      - isNotEmpty:
+          path: data.username
+      - isNotEmpty:
+          path: data.database
+      - isNotEmpty:
+          path: data.uri

--- a/charts/clickhouse/tests/service_test.yaml
+++ b/charts/clickhouse/tests/service_test.yaml
@@ -1,0 +1,77 @@
+suite: test clickhouse service
+templates:
+  - service.yaml
+tests:
+  - it: should create ClusterIP service by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-clickhouse
+
+  - it: should expose HTTP port 8123
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 8123
+            targetPort: http
+            protocol: TCP
+            name: http
+
+  - it: should expose TCP port 9000
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 9000
+            targetPort: tcp
+            protocol: TCP
+            name: tcp
+
+  - it: should create headless service
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-clickhouse-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: should support custom service ports
+    set:
+      service:
+        httpPort: 8124
+        tcpPort: 9001
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            port: 8124
+            targetPort: http
+            protocol: TCP
+            name: http
+      - contains:
+          path: spec.ports
+          content:
+            port: 9001
+            targetPort: tcp
+            protocol: TCP
+            name: tcp
+
+  - it: should support LoadBalancer service type
+    set:
+      service:
+        type: LoadBalancer
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer

--- a/charts/clickhouse/tests/volume-claim_test.yaml
+++ b/charts/clickhouse/tests/volume-claim_test.yaml
@@ -1,0 +1,64 @@
+suite: test clickhouse persistence
+templates:
+  - statefulset.yaml
+tests:
+  - it: should create volumeClaimTemplate when persistence is enabled
+    asserts:
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should use emptyDir when persistence is disabled
+    set:
+      persistence:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: should use existingClaim when set
+    set:
+      persistence:
+        existingClaim: "my-existing-pvc"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+
+  - it: should use custom storageClass
+    set:
+      persistence:
+        storageClass: "fast-ssd"
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: fast-ssd
+
+  - it: should set empty storageClass when set to dash
+    set:
+      persistence:
+        storageClass: "-"
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: ""
+
+  - it: should use custom persistence size
+    set:
+      persistence:
+        size: 50Gi
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 50Gi

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -1,0 +1,556 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "args": {
+            "type": "array"
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "database": {
+                    "type": "string"
+                },
+                "existingSecret": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "secretKeys": {
+                    "type": "object",
+                    "properties": {
+                        "passwordKey": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "command": {
+            "type": "array"
+        },
+        "commonAnnotations": {
+            "type": "object"
+        },
+        "commonLabels": {
+            "type": "object"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "existingConfigmap": {
+                    "type": "string"
+                },
+                "existingUsersConfigmap": {
+                    "type": "string"
+                },
+                "extraConfig": {
+                    "type": "string"
+                },
+                "extraUsersConfig": {
+                    "type": "string"
+                },
+                "listenHost": {
+                    "type": "string"
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "maxConcurrentQueries": {
+                    "type": "integer"
+                },
+                "maxConnections": {
+                    "type": "integer"
+                },
+                "maxMemoryUsage": {
+                    "type": "integer"
+                },
+                "timezone": {
+                    "type": "string"
+                }
+            }
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "extraEnvVars": {
+            "type": "array"
+        },
+        "extraEnvVarsSecret": {
+            "type": "string"
+        },
+        "extraObjects": {
+            "type": "array"
+        },
+        "extraVolumeMounts": {
+            "type": "array"
+        },
+        "extraVolumes": {
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "gatewayAPI": {
+            "type": "object",
+            "properties": {
+                "httpRoute": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "hostnames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "parentRefs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    },
+                                    "sectionName": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "rules": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "matches": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "enableServiceLinks": {
+                    "type": "boolean"
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "imageRegistry": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "imagePullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "className": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "initContainers": {
+            "type": "array"
+        },
+        "initdb": {
+            "type": "object",
+            "properties": {
+                "scripts": {
+                    "type": "object"
+                },
+                "scriptsConfigMap": {
+                    "type": "string"
+                }
+            }
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "namespaceSelector": {
+                            "type": "object"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "selector": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "accessModes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "existingClaim": {
+                    "type": "string"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "storageClass": {
+                    "type": "string"
+                },
+                "subPath": {
+                    "type": "string"
+                },
+                "volumeName": {
+                    "type": "string"
+                }
+            }
+        },
+        "persistentVolumeClaimRetentionPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "whenDeleted": {
+                    "type": "string"
+                },
+                "whenScaled": {
+                    "type": "string"
+                }
+            }
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podLabels": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                }
+            }
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "externalTrafficPolicy": {
+                    "type": "string"
+                },
+                "httpPort": {
+                    "type": "integer"
+                },
+                "loadBalancerIP": {
+                    "type": "string"
+                },
+                "nodePort": {
+                    "type": "integer"
+                },
+                "tcpPort": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "startupProbe": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "failureThreshold": {
+                    "type": "integer"
+                },
+                "initialDelaySeconds": {
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/clickhouse/values.schema.json
+++ b/charts/clickhouse/values.schema.json
@@ -33,6 +33,17 @@
                 }
             }
         },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "clusterDomain": {
+            "type": "string"
+        },
         "command": {
             "type": "array"
         },
@@ -56,6 +67,9 @@
                 },
                 "extraUsersConfig": {
                     "type": "string"
+                },
+                "interserverHttpPort": {
+                    "type": "integer"
                 },
                 "listenHost": {
                     "type": "string"
@@ -276,6 +290,129 @@
                 },
                 "scriptsConfigMap": {
                     "type": "string"
+                }
+            }
+        },
+        "keeper": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraConfig": {
+                    "type": "string"
+                },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "imagePullPolicy": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "maxUnavailable": {
+                            "type": "integer"
+                        },
+                        "minAvailable": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "accessModes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        },
+                        "volumeName": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "podManagementPolicy": {
+                    "type": "string"
+                },
+                "ports": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "type": "integer"
+                        },
+                        "raft": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "raftLogsLevel": {
+                    "type": "string"
+                },
+                "replicaCount": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
                 }
             }
         },

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -1,0 +1,351 @@
+## @section Global parameters
+global:
+  ## @param global.imageRegistry Global Docker Image registry
+  imageRegistry: ""
+  ## @param global.imagePullSecrets Global Docker registry secret names as an array
+  imagePullSecrets: []
+  enableServiceLinks: true
+
+## @section Common parameters
+## @param nameOverride String to partially override clickhouse.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override clickhouse.fullname
+fullnameOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+commonAnnotations: {}
+## @param priorityClassName Priority class name to be used for the pods
+priorityClassName: ""
+
+## @param terminationGracePeriodSeconds Time for Kubernetes to wait for the pod to gracefully terminate
+terminationGracePeriodSeconds: 30
+
+## @section ClickHouse image configuration
+image:
+  ## @param image.registry ClickHouse image registry
+  registry: docker.io
+  ## @param image.repository ClickHouse image repository
+  repository: clickhouse/clickhouse-server
+  ## @param image.tag ClickHouse image tag (immutable tags are recommended)
+  tag: "25.3@sha256:b627d7a9bc0e0c1bac26cdbe9d2fc6316faa29c5d8a174f28f5abd57d0fa6ba2"
+  ## @param image.imagePullPolicy ClickHouse image pull policy
+  imagePullPolicy: Always
+
+## @section Deployment configuration
+## @param replicaCount Number of ClickHouse replicas to deploy
+replicaCount: 1
+
+## @section Pod annotations and labels
+## @param podAnnotations Map of annotations to add to the pods
+podAnnotations: {}
+## @param podLabels Map of labels to add to the pods
+podLabels: {}
+
+## @section Security Context
+podSecurityContext:
+  ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
+  fsGroup: 101
+
+containerSecurityContext:
+  ## @param containerSecurityContext.allowPrivilegeEscalation Enable container privilege escalation
+  allowPrivilegeEscalation: false
+  ## @param containerSecurityContext.runAsNonRoot Configure the container to run as a non-root user
+  runAsNonRoot: true
+  ## @param containerSecurityContext.runAsUser User ID for the ClickHouse container
+  runAsUser: 101
+  ## @param containerSecurityContext.runAsGroup Group ID for the ClickHouse container
+  runAsGroup: 101
+  ## @param containerSecurityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
+  readOnlyRootFilesystem: false
+  ## @param containerSecurityContext.capabilities.drop Linux capabilities to be dropped
+  capabilities:
+    drop:
+      - ALL
+
+## @section ClickHouse Authentication
+auth:
+  ## @param auth.username ClickHouse admin username
+  username: "default"
+  ## @param auth.password Password for the ClickHouse admin user (auto-generated if empty)
+  password: ""
+  ## @param auth.database Default database to create at initialisation
+  database: "default"
+  ## @param auth.existingSecret Name of existing secret to use for ClickHouse credentials
+  existingSecret: ""
+  secretKeys:
+    ## @param auth.secretKeys.passwordKey Name of key in existing secret for ClickHouse admin password
+    passwordKey: "clickhouse-password"
+
+## @section ClickHouse Configuration
+config:
+  ## @param config.existingConfigmap Name of existing ConfigMap with ClickHouse configuration (config.xml)
+  existingConfigmap: ""
+  ## @param config.existingUsersConfigmap Name of existing ConfigMap with ClickHouse users configuration (users.xml)
+  existingUsersConfigmap: ""
+  ## @param config.listenHost Listen host for ClickHouse (default: listen on all interfaces)
+  listenHost: "0.0.0.0"
+  ## @param config.maxConnections Maximum number of simultaneous client connections
+  maxConnections: 4096
+  ## @param config.maxConcurrentQueries Maximum number of simultaneously processed queries
+  maxConcurrentQueries: 100
+  ## @param config.maxMemoryUsage Maximum memory usage for a single query in bytes (0 = unlimited)
+  maxMemoryUsage: 0
+  ## @param config.timezone Default timezone
+  timezone: "UTC"
+  ## @param config.logLevel Log level (trace, debug, information, warning, error, fatal)
+  logLevel: "information"
+  ## @param config.extraConfig Additional ClickHouse XML configuration snippets merged into config.xml
+  extraConfig: ""
+  ## @param config.extraUsersConfig Additional ClickHouse XML configuration snippets merged into users.xml
+  extraUsersConfig: ""
+
+## @section ClickHouse Initialization scripts
+initdb:
+  ## @param initdb.scripts Dictionary of SQL scripts to run at first boot (key: filename, value: SQL content)
+  scripts: {}
+  ## @param initdb.scriptsConfigMap ConfigMap with SQL scripts to be run at first boot
+  scriptsConfigMap: ""
+
+## @section Service configuration
+service:
+  ## @param service.type ClickHouse service type
+  type: ClusterIP
+  ## @param service.httpPort ClickHouse HTTP interface port
+  httpPort: 8123
+  ## @param service.tcpPort ClickHouse TCP (native) interface port
+  tcpPort: 9000
+  ## @param service.nodePort NodePort for TCP service (only used when type=NodePort)
+  nodePort: 30900
+  ## @param service.annotations Service annotations
+  annotations: {}
+  ## @param service.loadBalancerIP LoadBalancer IP if service type is `LoadBalancer`
+  loadBalancerIP: ""
+  ## @param service.externalTrafficPolicy External traffic policy for the service
+  externalTrafficPolicy: ""
+
+## @section Ingress configuration
+ingress:
+  ## @param ingress.enabled Enable ingress record generation for ClickHouse HTTP interface
+  enabled: false
+  ## @param ingress.className IngressClass that will be used to implement the Ingress
+  className: ""
+  ## @param ingress.annotations Additional annotations for the Ingress resource
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  ## @param ingress.hosts[0].host Hostname for ClickHouse ingress
+  ## @param ingress.hosts[0].paths[0].path Path for ClickHouse ingress
+  ## @param ingress.hosts[0].paths[0].pathType Path type for ClickHouse ingress
+  hosts:
+    - host: clickhouse.local
+      paths:
+        - path: /
+          pathType: Prefix
+  ## @param ingress.tls TLS configuration for ClickHouse ingress
+  tls: []
+  #  - secretName: clickhouse-tls
+  #    hosts:
+  #      - clickhouse.local
+
+## @section Gateway API parameters
+gatewayAPI:
+  httpRoute:
+    ## @param gatewayAPI.httpRoute.enabled Enable Gateway API HTTPRoute generation for ClickHouse
+    enabled: false
+    ## @param gatewayAPI.httpRoute.annotations Additional annotations for the HTTPRoute resource
+    annotations: {}
+    ## @param gatewayAPI.httpRoute.parentRefs References to the parent Gateways
+    parentRefs:
+      - name: gateway
+        namespace: ""
+        sectionName: ""
+    ## @param gatewayAPI.httpRoute.hostnames List of hostnames to match
+    hostnames:
+      - clickhouse.local
+    ## @param gatewayAPI.httpRoute.rules HTTPRoute rules
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+
+## @section Resources
+resources: {}
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: "2"
+  #   memory: 4Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
+
+## @section Persistence
+persistence:
+  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+  enabled: true
+  ## @param persistence.storageClass Persistent Volume storage class
+  storageClass: ""
+  ## @param persistence.annotations Persistent Volume Claim annotations
+  annotations: {}
+  ## @param persistence.size Persistent Volume size
+  size: 10Gi
+  ## @param persistence.accessModes Persistent Volume access modes
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+  existingClaim: ""
+  ## @param persistence.subPath The subdirectory of the volume to mount to
+  subPath: ""
+  ## @param persistence.labels Labels for persistent volume claims
+  labels: {}
+  ## @param persistence.volumeName Container volume name and volume claim prefix
+  volumeName: "data"
+
+## @section Persistent Volume Claim Retention Policy
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for the Statefulset
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  whenDeleted: Retain
+
+## @section Liveness and readiness probes
+livenessProbe:
+  ## @param livenessProbe.enabled Enable livenessProbe on ClickHouse containers
+  enabled: true
+  ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  initialDelaySeconds: 30
+  ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+  periodSeconds: 10
+  ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  timeoutSeconds: 5
+  ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+  failureThreshold: 3
+  ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+  successThreshold: 1
+
+readinessProbe:
+  ## @param readinessProbe.enabled Enable readinessProbe on ClickHouse containers
+  enabled: true
+  ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  initialDelaySeconds: 10
+  ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+  periodSeconds: 5
+  ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  timeoutSeconds: 5
+  ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+  failureThreshold: 3
+  ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+  successThreshold: 1
+
+startupProbe:
+  ## @param startupProbe.enabled Enable startupProbe on ClickHouse containers
+  enabled: true
+  ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  initialDelaySeconds: 30
+  ## @param startupProbe.periodSeconds Period seconds for startupProbe
+  periodSeconds: 10
+  ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  timeoutSeconds: 5
+  ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+  failureThreshold: 30
+  ## @param startupProbe.successThreshold Success threshold for startupProbe
+  successThreshold: 1
+
+## @section Node Selection
+## @param nodeSelector Node labels for pod assignment
+nodeSelector: {}
+
+## @param tolerations Toleration labels for pod assignment
+tolerations: []
+
+## @param affinity Affinity settings for pod assignment
+affinity: {}
+
+## @section Service Account
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  create: false
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  annotations: {}
+  ## @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template.
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
+  automountServiceAccountToken: false
+
+## @param extraEnvVars Additional environment variables to set
+extraEnvVars: []
+  # - name: CUSTOM_VAR
+  #   value: "custom-value"
+
+## @param extraEnvVarsSecret Name of a secret containing additional environment variables
+extraEnvVarsSecret: ""
+
+## @param extraVolumes Additional volumes to add to the pod
+extraVolumes: []
+
+## @param extraVolumeMounts Additional volume mounts to add to the ClickHouse container
+extraVolumeMounts: []
+
+## @param initContainers Init containers to add to the ClickHouse pods
+initContainers: []
+
+## @param command Override default container command
+command: []
+
+## @param args Override default container args
+args: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []
+
+## @section Metrics configuration
+metrics:
+  ## @param metrics.enabled Start a sidecar prometheus exporter to expose ClickHouse metrics
+  enabled: false
+  image:
+    ## @param metrics.image.registry ClickHouse exporter image registry
+    registry: docker.io
+    ## @param metrics.image.repository ClickHouse exporter image repository
+    repository: altinity/clickhouse-exporter
+    ## @param metrics.image.tag ClickHouse exporter image tag
+    tag: "0.0.2@sha256:d19bb9e5e42c3eedbb14e1da7e43b59de86cf87b0012f9acb6c7d74e69cefb58"
+    ## @param metrics.image.pullPolicy ClickHouse exporter image pull policy
+    pullPolicy: Always
+  ## @param metrics.resources Resource limits and requests for metrics container
+  resources: {}
+  ## Metrics service configuration
+  service:
+    ## @param metrics.service.annotations Additional custom annotations for Metrics service
+    annotations: {}
+    ## @param metrics.service.labels Additional custom labels for Metrics service
+    labels: {}
+    ## @param metrics.service.port Metrics service port
+    port: 9116
+  ## Prometheus Operator ServiceMonitor configuration
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    scrapeTimeout: 10s
+    ## @param metrics.serviceMonitor.selector Additional labels for ServiceMonitor resource
+    selector: {}
+    ## @param metrics.serviceMonitor.annotations ServiceMonitor annotations
+    annotations: {}
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    honorLabels: false
+    ## @param metrics.serviceMonitor.relabelings ServiceMonitor relabel configs to apply to samples before scraping
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings ServiceMonitor metricRelabelings configs to apply to samples before ingestion
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.namespaceSelector ServiceMonitor namespace selector
+    namespaceSelector: {}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -97,9 +97,9 @@ config:
   logLevel: "information"
   ## @param config.interserverHttpPort Port used for data replication between ClickHouse replicas (only wired when keeper.enabled)
   interserverHttpPort: 9009
-  ## @param config.extraConfig Additional ClickHouse XML configuration snippets merged into config.xml
+  ## @param config.extraConfig Additional ClickHouse XML configuration snippets merged into config.xml. Rendered with `tpl`, so Helm template expressions (e.g. `{{ .Release.Namespace }}`) are supported.
   extraConfig: ""
-  ## @param config.extraUsersConfig Additional ClickHouse XML configuration snippets merged into users.xml
+  ## @param config.extraUsersConfig Additional ClickHouse XML configuration snippets merged into users.xml. Rendered with `tpl` (Helm template expressions supported).
   extraUsersConfig: ""
 
 ## @section ClickHouse Initialization scripts

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -95,6 +95,8 @@ config:
   timezone: "UTC"
   ## @param config.logLevel Log level (trace, debug, information, warning, error, fatal)
   logLevel: "information"
+  ## @param config.interserverHttpPort Port used for data replication between ClickHouse replicas (only wired when keeper.enabled)
+  interserverHttpPort: 9009
   ## @param config.extraConfig Additional ClickHouse XML configuration snippets merged into config.xml
   extraConfig: ""
   ## @param config.extraUsersConfig Additional ClickHouse XML configuration snippets merged into users.xml
@@ -349,3 +351,82 @@ metrics:
     metricRelabelings: []
     ## @param metrics.serviceMonitor.namespaceSelector ServiceMonitor namespace selector
     namespaceSelector: {}
+
+## @section Cluster topology
+## @param clusterDomain Kubernetes cluster domain used to build stable in-cluster DNS names
+clusterDomain: cluster.local
+cluster:
+  ## @param cluster.name Logical ClickHouse cluster name used in <remote_servers> and the {cluster} macro
+  name: default
+
+## @section ClickHouse Keeper (Raft coordination — required for ReplicatedMergeTree / ON CLUSTER)
+## When enabled, a dedicated ClickHouse Keeper StatefulSet is deployed and ClickHouse is wired to it
+## (<zookeeper>, <remote_servers>, <macros>, <interserver_http_credentials>). Disabled by default so the
+## chart stays a standalone single-node ClickHouse, identical to upstream.
+keeper:
+  ## @param keeper.enabled Deploy a ClickHouse Keeper quorum and wire ClickHouse to it
+  enabled: false
+  ## @param keeper.replicaCount Number of Keeper replicas (use an odd number for a Raft quorum, e.g. 3)
+  replicaCount: 3
+  image:
+    ## @param keeper.image.registry ClickHouse Keeper image registry
+    registry: docker.io
+    ## @param keeper.image.repository ClickHouse Keeper image repository
+    repository: clickhouse/clickhouse-keeper
+    ## @param keeper.image.tag ClickHouse Keeper image tag (immutable tags are recommended)
+    tag: "25.3"
+    ## @param keeper.image.imagePullPolicy ClickHouse Keeper image pull policy
+    imagePullPolicy: IfNotPresent
+  ports:
+    ## @param keeper.ports.client Keeper client port (ClickHouse connects here via <zookeeper>)
+    client: 9181
+    ## @param keeper.ports.raft Keeper Raft inter-node port
+    raft: 9234
+  ## @param keeper.raftLogsLevel Raft logs verbosity (trace, debug, information, warning, error)
+  raftLogsLevel: "warning"
+  ## @param keeper.podManagementPolicy StatefulSet pod management policy for the Keeper quorum
+  podManagementPolicy: Parallel
+  persistence:
+    ## @param keeper.persistence.enabled Enable persistence for Keeper coordination data
+    enabled: true
+    ## @param keeper.persistence.storageClass Persistent Volume storage class for Keeper
+    storageClass: ""
+    ## @param keeper.persistence.size Persistent Volume size for Keeper
+    size: 8Gi
+    ## @param keeper.persistence.accessModes Persistent Volume access modes for Keeper
+    accessModes:
+      - ReadWriteOnce
+    ## @param keeper.persistence.annotations Persistent Volume Claim annotations for Keeper
+    annotations: {}
+    ## @param keeper.persistence.volumeName Keeper volume name and volume claim prefix
+    volumeName: "data"
+  service:
+    ## @param keeper.service.type Keeper client service type
+    type: ClusterIP
+    ## @param keeper.service.annotations Keeper client service annotations
+    annotations: {}
+  pdb:
+    ## @param keeper.pdb.create Create a PodDisruptionBudget for the Keeper quorum
+    create: false
+    ## @param keeper.pdb.minAvailable Minimum available Keeper pods (set either minAvailable or maxUnavailable)
+    minAvailable: ""
+    ## @param keeper.pdb.maxUnavailable Maximum unavailable Keeper pods
+    maxUnavailable: 1
+  ## @param keeper.resources Resource limits and requests for the Keeper container
+  resources: {}
+  ## @param keeper.podAnnotations Map of annotations to add to the Keeper pods
+  podAnnotations: {}
+  ## @param keeper.podLabels Map of labels to add to the Keeper pods
+  podLabels: {}
+  ## @param keeper.nodeSelector Node labels for Keeper pod assignment
+  nodeSelector: {}
+  ## @param keeper.affinity Affinity for Keeper pod assignment
+  affinity: {}
+  ## @param keeper.tolerations Tolerations for Keeper pod assignment
+  tolerations: []
+  ## @param keeper.extraConfig Additional Keeper XML configuration snippets merged into keeper_config.xml
+  extraConfig: ""
+  ## @param keeper.extraVolumes Extra volumes for the Keeper pod
+  extraVolumes: []
+  ## @param keeper.extraVolumeMounts Extra volume mounts for the Keeper container
+  extraVolumeMounts: []


### PR DESCRIPTION
> Supersedes #62 (same content — that PR was auto-closed when its branch was renamed to carry the `ENT-3986` identifier).

Closes ENT-3986.

## What

Adds a **ClickHouse** chart to the fork, in two commits:

1. **Replicate** upstream [CloudPirates-io/helm-charts#1199](https://github.com/CloudPirates-io/helm-charts/pull/1199) — byte-identical standalone ClickHouse chart on the `cloudpirates` common lib (v0.1.0).
2. **ClickHouse Keeper** support — the missing piece so clustering / `ReplicatedMergeTree` / `ON CLUSTER` is testable.

## ClickHouse Keeper extension

- `templates/keeper/`: dedicated Keeper StatefulSet (per-pod `server_id` from the pod ordinal), Raft config ConfigMap, headless service (stable member DNS), client service (`9181`), opt-in PDB.
- When `keeper.enabled=true`: ClickHouse is wired with `<zookeeper>`, a single-shard `<remote_servers>` cluster across the replicas, per-pod `<macros>` (`POD_NAME`), and `<interserver_http_credentials>`.
- `app.kubernetes.io/component` (`server`/`keeper`) isolates the two workloads' selectors.
- Opt-in (`keeper.enabled: false` by default → standalone, identical to upstream); `replicaCount: 3` Raft quorum when enabled. Chart bumped to v0.2.0.

## Validation

`helm lint --strict` ✅ · `helm unittest` ✅ (35 tests) · `helm template` with keeper enabled renders the Keeper StatefulSet, Raft config (correct DNS/ids) and the cluster wiring.
